### PR TITLE
Introduce unified Thalia credential (master)

### DIFF
--- a/Thalia/Issues/README.md
+++ b/Thalia/Issues/README.md
@@ -1,0 +1,8 @@
+Thalia Credentials
+==================
+
+In the original set-up, we had seperate credentials for age, membership type and
+who someone was.
+
+In the new set-up we have merged these into a single 'thalia' credential with
+several attributes. By this we hope to speed up verification times.

--- a/Thalia/Issues/thalia/description.xml
+++ b/Thalia/Issues/thalia/description.xml
@@ -1,0 +1,29 @@
+<IssueSpecification>
+	<Name>Thalia credential</Name>
+	<IssuerID>Thalia</IssuerID>
+	<ShortName>Thalia</ShortName>
+	<CredentialID>thalia</CredentialID>
+	<Description>
+		Credential issued by Student association Thalia. The UserID is the
+        same as the userid on http://thalia.nu.
+
+        Contains the kind of member you are and if you are over 18.
+	</Description>
+
+	<Id>31337</Id>
+
+	<Attributes>
+		<Attribute>
+			<Name>userID</Name>
+			<Description>Username on http://thalia.nu</Description>
+		</Attribute>
+        <Attribute>
+            <Name>over18</Name>
+            <Description>If you are over 18</Description>
+        </Attribute>
+        <Attribute>
+            <Name>memberType</Name>
+            <Description>The kind of member</Description>
+        </Attribute>
+	</Attributes>
+</IssueSpecification>

--- a/Thalia/Verifies/begunstiger/description.xml
+++ b/Thalia/Verifies/begunstiger/description.xml
@@ -2,7 +2,7 @@
 	<Name>Thalia Begunstiger</Name>
 
 	<IssuerID>Thalia</IssuerID>
-	<CredentialID>member</CredentialID>
+	<CredentialID>membership</CredentialID>
 
 	<VerifierID>Thalia</VerifierID>
 	<VerificationID>begunstiger</VerificationID>

--- a/Thalia/Verifies/honoraryMember/description.xml
+++ b/Thalia/Verifies/honoraryMember/description.xml
@@ -2,7 +2,7 @@
 	<Name>Thalia honorary member</Name>
 
 	<IssuerID>Thalia</IssuerID>
-	<CredentialID>member</CredentialID>
+	<CredentialID>membership</CredentialID>
 
 	<VerifierID>Thalia</VerifierID>
 	<VerificationID>honoraryMember</VerificationID>

--- a/Thalia/Verifies/member/description.xml
+++ b/Thalia/Verifies/member/description.xml
@@ -2,7 +2,7 @@
 	<Name>Thalia full member</Name>
 
 	<IssuerID>Thalia</IssuerID>
-	<CredentialID>member</CredentialID>
+	<CredentialID>membership</CredentialID>
 
 	<VerifierID>Thalia</VerifierID>
 	<VerificationID>member</VerificationID>

--- a/Thalia/Verifies/thaliaAll/description.xml
+++ b/Thalia/Verifies/thaliaAll/description.xml
@@ -1,0 +1,21 @@
+<VerifySpecification>
+	<Name>Thalia: All Attributes</Name>
+
+	<IssuerID>Thalia</IssuerID>
+	<CredentialID>thalia</CredentialID>
+
+	<VerifierID>Thalia</VerifierID>
+	<VerificationID>thaliaAll</VerificationID>
+
+	<Id>1538</Id>
+
+	<Description>
+		Read entire Thalia root credential for administrative purposes.
+	</Description>
+
+	<AttributeModes>
+		<AttributeMode id="userID" mode="revealed" />
+        <AttributeMode id="over18" mode="revealed" />
+        <AttributeMode id="memberType" mode="revealed" />
+	</AttributeModes>
+</VerifySpecification>

--- a/Thalia/Verifies/thaliaMemberType/description.xml
+++ b/Thalia/Verifies/thaliaMemberType/description.xml
@@ -1,0 +1,21 @@
+<VerifySpecification>
+    <Name>Thalia: type of member</Name>
+
+	<IssuerID>Thalia</IssuerID>
+	<CredentialID>thalia</CredentialID>
+
+	<VerifierID>Thalia</VerifierID>
+	<VerificationID>thaliaMemberType</VerificationID>
+
+	<Id>1540</Id>
+
+	<Description>
+		Read the member type from the Thalia credential.
+	</Description>
+
+	<AttributeModes>
+		<AttributeMode id="userID" mode="unrevealed" />
+        <AttributeMode id="over18" mode="unrevealed" />
+        <AttributeMode id="memberType" mode="revealed" />
+	</AttributeModes>
+</VerifySpecification>

--- a/Thalia/Verifies/thaliaOver18/description.xml
+++ b/Thalia/Verifies/thaliaOver18/description.xml
@@ -1,0 +1,21 @@
+<VerifySpecification>
+	<Name>Thalia: over18</Name>
+
+	<IssuerID>Thalia</IssuerID>
+	<CredentialID>thalia</CredentialID>
+
+	<VerifierID>Thalia</VerifierID>
+	<VerificationID>thaliaOver18</VerificationID>
+
+	<Id>1539</Id>
+
+	<Description>
+		Read the over18 credential
+	</Description>
+
+	<AttributeModes>
+		<AttributeMode id="userID" mode="unrevealed" />
+        <AttributeMode id="over18" mode="revealed" />
+        <AttributeMode id="memberType" mode="unrevealed" />
+	</AttributeModes>
+</VerifySpecification>

--- a/Thalia/description.xml
+++ b/Thalia/description.xml
@@ -5,5 +5,5 @@
   6525 AJ, Nijmegen</ContactAddress>
   <ContactEMail>identificaatcie@thalia.nu</ContactEMail>
 
-  <baseURL>http://www.thalia.nu/irma/</baseURL>
+  <baseURL>http://www.thalia.nu/irma/Thalia/</baseURL>
 </Issuer>

--- a/Thalia/gp.xml
+++ b/Thalia/gp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <GroupParameters xmlns="http://www.zurich.ibm.com/security/idemix" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.zurich.ibm.com/security/idemix GroupParameters.xsd">
   <References>
-      <SystemParameters>http://www.thalia.nu/irma/sp.xml</SystemParameters>
+      <SystemParameters>http://www.thalia.nu/irma/Thalia/sp.xml</SystemParameters>
   </References>
   <Elements>
     <Gamma>916529013323708810925262285853943751412716639260948397315456236828060646877579669766886172962907248783979898033796091062325584064802287728294468642896625540973839483206710301877044439993929928642627540845322563879925233590363456951</Gamma>


### PR DESCRIPTION
In the original set-up, we had separate credentials for age, membership type and who someone was.

In the new set-up we have merged these into a single 'thalia' credential with several attributes. By this we hope to speed up verification times.
